### PR TITLE
User report: Fix typo and revise intro sentence

### DIFF
--- a/api-docs/concepts.rst
+++ b/api-docs/concepts.rst
@@ -3,7 +3,7 @@
 Concepts
 ----------
 
-Review the following key terms and architectural overview to learn how you the Cloud Keep API enables secure life-cycle management for keys and credentials.
+Review the following key terms and architectural overview to learn how Cloud Keep enables secure life-cycle management for keys and credentials.
 
 
 .. _Barbican-dg-key-terms:

--- a/api-docs/concepts.rst
+++ b/api-docs/concepts.rst
@@ -3,8 +3,7 @@
 Concepts
 ----------
 
-his section describes the key terms and concepts that apply to Rackspace Cloud Keep, and
-provides an overview of the Rackspace Cloud Keep architecture.
+Review the following key terms and architectural overview to learn how you the Cloud Keep API enables secure life-cycle management for keys and credentials.
 
 
 .. _Barbican-dg-key-terms:


### PR DESCRIPTION
Update per e-mail: 

Hello Knowledge Center Team,
I was reviewing the dev guide for Cloud Keep and spotted a small error in the docs.
https://developer.rackspace.com/docs/cloud-keep/v1/developer-guide/#concepts

Under Concepts
The line with the issue, looks like the "his" should be "This":
his section describes the key terms and concepts that apply to Rackspace Cloud Keep, and provides an overview of the Rackspace Cloud Keep architecture.
I think it should read:
This section describes the key terms and concepts that apply to Rackspace Cloud Keep, and provides an overview of the Rackspace Cloud Keep architecture.
 
Thank you for your help in resolving the issue,
Weston Pierry 
Escalation Support for Cloud
Rackspace Cloud
Toll free: 1-888-850-3994
International: +44(0)20 8734 4029