### PR TITLE
remove CDN reference and add Barbican info to top of GS guide

### DIFF
--- a/api-docs/getting-started.rst
+++ b/api-docs/getting-started.rst
@@ -7,13 +7,5 @@
 Use this Getting Started Guide to learn how to authenticate, send API requests,
 and complete basic operations with Cloud Keep API.
 
-For additional details
-about all of the API operations, see the :ref:`API reference <api-reference>`.
-
-
-
-Use this Getting Started Guide to learn how to authenticate, send API requests, 
-and complete basic operations by using the Rackspace CDN API.
-
 For more information about |product name| concepts and API operations, see the 
 :ref:`Developer Guide<developer-guide>` and the :ref:`API Reference<api-reference>`.

--- a/api-docs/overview/index.rst
+++ b/api-docs/overview/index.rst
@@ -5,7 +5,9 @@ About the API
 
 |product name| provides a REST API that enables secure life-cycle
 management of keys and credentials, called secrets, on behalf of
-customers. Using the API, you can securely store and retrieve credentials systematically 
+customers. It is based on OpenStack Barbican, a community-led open-source platform.
+
+Using the API, you can securely store and retrieve credentials systematically 
 and enable users to have keys generated on their behalf based on their requested 
 encryption algorithm and bit length.
 


### PR DESCRIPTION
removed old reference to CDN

Added info stating that Keep is based on OpenStack Barbican.