### PR TITLE
Update RBAC information with Rackspace common content

### DIFF
--- a/api-docs/general-api-info/role-based-access-control.rst
+++ b/api-docs/general-api-info/role-based-access-control.rst
@@ -1,24 +1,141 @@
-.. _barbican-dg-rbac:
+.. _role-based-access-control:
 
-Role Based Access Control
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Like many other services, the |product name| service supports the protection of
-its APIs by enforcing Role Based Access Control rules.  You can grant roles
-to sub-accounts to allow or prevent access to secrets stored in |product name|
+================================
+Role-based access control (RBAC)
+================================
 
-The account owner always has full access to all resources stored in |product name|,
-while new sub-accounts will have no access by default.
+Role-based access control (RBAC) restricts access to the capabilities of
+Rackspace Cloud services, including the |product name| API, to authorized
+users only. RBAC enables Rackspace Cloud customers to specify
+users have access to which |product name| API
+service capabilities, based on roles defined by Rackspace. The
+permissions to perform certain operations in |product name| API (create,
+read, update, delete) are assigned to specific roles. The account owner user
+assigns these roles, either global (multiproduct) or product-specific (for
+example, |product name|), to account users.
 
-The different roles that can be granted to sub-accounts will limit the amount
-of access each sub-account has for all resources stored in |product name| as
-listed in the following table:
+.. _rbac-assign:
 
-.. csv-table::
-   :header: "Role", "Read Metadata", "Retrieve Payloads", "Store new secrets", "Delete secrets"
+Assigning roles to account users
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   "keep:admin", "x", "x", "x", "x"
-   "keep:creator", "x", "x", "x"
-   "keep:observer or observer", "x", "x"
-   "keep:audit", "x"
+The account owner (identity:user-admin) can create account users on the
+account and then assign roles to those users. The roles grant the account
+users specific permissions for accessing the capabilities of the
+|product name| service. Each account has only one account owner, and that role
+is assigned by default to any Rackspace Cloud account when the account is
+created.
 
+See the Cloud Identity API guide for information about how to
+perform the following tasks:
+
+* :rax-devdocs:`Add account users <cloud-identity/v2/developer-guide/#add-user>`
+
+* :rax-devdocs:`Add role to user \
+  <cloud-identity/v2/developer-guide/#add-role-to-user>`
+
+* :rax-devdocs:`Delete global role from user \
+  <cloud-identity/v2/developer-guide/#delete-global-role-from-user>`
+
+.. note::
+
+    The account owner (identity:user-admin) role cannot hold any
+    additional roles because it already has full access to all capabilities.
+
+
+.. _rbac-available-roles:
+
+Roles available for |product name|
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following table describes the roles that can be used to access the
+|product name| API.
+
+.. list-table:: **Product roles and capabilities**
+   :widths: 20 50
+   :header-rows: 1
+
+   * - Role name
+     - Role permissions
+   * - keep:admin
+     - This role provides Create, Update, Read Metadata, Decrypt Payload,
+       and Delete permissions in |product name|, where access is granted.
+   * - keep:creator
+     - This role provides Create, Update, Read Metadata, and Decrypt Payload
+       permissions in |product name|, where access is granted.
+   * - keep:observer
+     - This role provides Read Metadata and Decrypt Payload permissions in
+       |product name|, where access is granted.
+   * - keep:audit
+     - This role provides Read Metadata permission in |product name|, where
+       access is granted.
+
+.. _rbac-available-multi-roles:
+
+Multiproduct global roles and permissions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Additionally, two multiproduct roles apply to all products. Users with
+multiproduct roles inherit access to products when those products become
+RBAC-enabled. The following table describes these roles and their permissions.
+
+**Multiproduct roles and permissions**
+
+.. list-table:: **Multiproduct roles and permissions**
+   :widths: 20 40
+   :header-rows: 1
+
+   * - Role name
+     - Role permissions
+   * - admin
+     - This role provides create, read, update, and delete permissions
+       in all products, where access is granted.
+   * - observer
+     - This role provides read permission in all products,
+       where access is granted.
+
+.. _rbac-resolve-role-conflict:
+
+Resolving conflicts between RBAC multiproduct and product-specific roles
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The account owner can set roles for both multiproduct and |product name|
+scope, and it is important to understand how any potential conflicts between
+these roles are resolved. When two roles appear to conflict, the role that
+provides the more extensive permissions takes precedence. Therefore, admin
+roles take precedence over observer and creator roles, because admin roles
+provide more permissions.
+
+The following table shows two examples of how potential conflicts between user
+roles in the Control Panel are resolved.
+
+
+.. list-table:: **Example of resolving permissions**
+   :widths: 10 10 40
+   :header-rows: 1
+
+   * - Permission configuration
+     - Control Panel permission view
+     - Control Panel admin capabilities
+   * - User is assigned the following roles: multiproduct **observer** and
+       |product name| **admin**
+     - Appears that the user has only the multiproduct **observer** role
+     - User can perform admin functions for |product name| only. The user has
+       the **observer** role for the rest of the products.
+   * - User is assigned to the following roles: multiproduct **admin** and
+       |product name| **observer**
+     - Appears that the user has only the multiprodcut **admin** role
+     - User can perform admin functions for all of the products.
+       The |product name| **observer** role is ignored.
+
+
+.. _keep-dg-api-info-rbac-permissions:
+
+RBAC permissions cross-reference to |product name| API operations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+API operations for |product name| may or may not be available to all
+roles. To see which operations are permitted to invoke which calls,
+review the :how-to:`Permissions Matrix for Role-Based Access Control (RBAC) \
+<permissions-matrix-for-role-based-access-control-rbac>`.


### PR DESCRIPTION
@dmend Standard text for Rackspace Cloud services RBAC is available in the [Rackspace API DevGuide template](https://github.com/rackerlabs/docs-common/tree/master/api-guide-template). 

I'm attaching a copy of the RBAC file here updated with the Cloud Keep info. (I changed the file extension from "rst" to "txt" so that I could attach it to this issue.  

[role-based-access-control.txt](https://github.com/rackerlabs/docs-barbican/files/364979/role-based-access-control.txt)

You can adapt the information to your product context, and update the current RBAC information as needed. I'm not sure if Cloud Keep has the same RBAC capabilities and Control Panel access as other products.  (Changed the file extension from "rst" to "txt" so I could attach it to this issue.
